### PR TITLE
version mismatch fix.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 WORKDIR /app
 


### PR DESCRIPTION
```
ERROR: Ignored the following versions that require a different python version: 2.1.0 Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement numpy==2.1.2

```